### PR TITLE
発話しなくてもslotにセットできるように修正

### DIFF
--- a/QlovaClient/QlovaClient.php
+++ b/QlovaClient/QlovaClient.php
@@ -274,7 +274,7 @@ class QlovaClient
             if (!empty($intentItem['slots'])) {
                 $idx = 1; // $match[0] はマッチしたパターン全体なのでスキップする
                 foreach ($intentItem['slots'] as $name => $delegate) {
-                    if (isset($match[$idx])) {
+                    if ($delegate !== false || isset($match[$idx])) {
                         $slots[$name] = [
                             'name' => $name,
                             'value' => $delegate ?: $match[$idx],


### PR DESCRIPTION
対話モードにて発話内容を全てタイプしなくても必要なスロット情報を送信できるようにした
このツールは発話の解析が目的ではないことに気付いた（いまさら